### PR TITLE
update viewer if atoms has a different uuid

### DIFF
--- a/weas_widget/index.js
+++ b/weas_widget/index.js
@@ -52,20 +52,23 @@ export function render({ model, el }) {
     // Listen for changes in the 'atoms' property
     model.on("change:atoms", () => {
         const data = model.get("atoms");
+        // if uuid of data and avr.atoms are not undefined and are the same, then skip
+        if (data.uuid && avr.atoms.uuid && avr.atoms.uuid === data.uuid) {
+            return;
+        }
         const atoms = new weas.Atoms(data);
         // Re-render with the new atoms data
-        avr.atoms = atoms;
-        // uuid is used to identify the atoms object in the viewer
-        // so that we can delete it later
-        atoms.uuid = avr.uuid;
+        avr.updateAtoms(atoms);
         avr.drawModels();
+        console.log("update viewer from Python.");
     });
     // Listen for the custom 'atomsUpdated' event
     viewerElement.addEventListener('atomsUpdated', (event) => {
         const updatedAtoms = event.detail.to_dict(); // event.detail contains the updated atoms
+        updatedAtoms.uuid = avr.atoms.uuid;
         model.set("atoms", updatedAtoms);
         model.save_changes();
-        console.log("Updated atoms: ", updatedAtoms);
+        console.log("Updated atoms from event.")
     });
     // Listen for the custom 'viewerUpdated' event
     // this include modelStyle, colorType, materialType, atomLabelType, etc


### PR DESCRIPTION


When a new atoms is passed from Python to the viewer, it will first check the uuid of the atoms and the uuid of the atoms in the viewer. Update the viewer and its plugins only when the uuids are different.


Here is the message chain, when user edit the atoms in the GUI.

1) users edit the atoms in the viewer (GUI) 
-->  2) add a new uuid to the viewer.atoms, and dispatch a `atomsUpdated` event; 
--> 3) An eventListener will trigger the update of the Python atoms;
 --->  4) trigger the function to update the viewer. In this step, we will check if the new atoms and the atoms from the viewer are the same or not (by a unique uuid). In this case, the uuids will be the same, so there is no need to update the viewer.

