### PR TITLE
Add factor to scale the length of the arrows in vector field

### DIFF
--- a/docs/source/vector_field.rst
+++ b/docs/source/vector_field.rst
@@ -40,7 +40,8 @@ One can visualize the phonon dispersion via lattice vibrations. One only need to
                                         [[0, 0], [0, 0], [-0.5, 0]]]
                                        ),
             "kpoint": [0, 0, 0], # optional
-            "amplitude": 5,
+            "amplitude": 5, # scale the motion of the atoms
+            "factor": 1.5, # scale the length of the arrows
             "nframes": 20,
             "repeat": [4, 4, 1],
             "color": "blue",

--- a/js/widget.js
+++ b/js/widget.js
@@ -52,7 +52,7 @@ function render({ model, el }) {
             _currentFrame: model.get("currentFrame"),
         };
         editor = new weas.WEAS({ domElement, atoms, viewerConfig, guiConfig });
-        window.editor = editor; // for debugging
+        // window.editor = editor; // for debugging
         editor.avr.selectedAtomsIndices = model.get("selectedAtomsIndices");
         // editor.avr.atomScales = model.get("atomScales");
         // editor.avr.modelSticks = model.get("modelSticks");
@@ -82,14 +82,8 @@ function render({ model, el }) {
         // if phone is not empty object, then create phonon mode
         if (Object.keys(phonon).length > 0) {
             editor.avr.fromPhononMode({
+                ...phonon,
                 atoms: atoms,
-                eigenvectors: phonon.eigenvectors,
-                amplitude: phonon.amplitude,
-                nframes: phonon.nframes,
-                kpoint: phonon.kpoint,
-                repeat: phonon.repeat,
-                color: phonon.color,
-                radius: phonon.radius,
             });
         }
         // camera settings

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"dependencies": {
 		"dat.gui": "^0.7.9",
 		"three": "^0.161.0",
-		"weas": ">=0.1.30"
+		"weas": ">=0.1.31"
 	},
 	"devDependencies": {
 		"esbuild": "^0.20.0"


### PR DESCRIPTION

```python
phonon_setting = {"eigenvectors": np.array([[[0, 0], [0, 0],[0.5, 0]],
                                        [[0, 0], [0, 0], [-0.5, 0]]]
                                       ),
            "kpoint": [0, 0, 0], # optional
            "amplitude": 5, # scale the motion of the atoms
            "factor": 1.5, # scale the length of the arrows
            "nframes": 20,
            "repeat": [4, 4, 1],
            "color": "blue",
            "radius": 0.1,
            }
```