### PR TITLE
Add show_out_boundary_bonds

### DIFF
--- a/js/widget.js
+++ b/js/widget.js
@@ -67,6 +67,7 @@ function render({ model, el }) {
         // bond settings
         // console.log("bondSettings: ", model.get("bondSettings"));
         editor.avr.bondManager.fromSettings(model.get("bondSettings"));
+        editor.avr.bondManager.showOutBoundaryBonds = model.get("showOutBoundaryBonds");
         // highlight settings
         // console.log("highlightSettings: ", model.get("highlightSettings"));
         editor.avr.highlightManager.fromSettings(model.get("highlightSettings"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 			"dependencies": {
 				"dat.gui": "^0.7.9",
 				"three": "^0.161.0",
-				"weas": ">=0.1.36"
+				"weas": ">=0.1.37"
 			},
 			"devDependencies": {
 				"esbuild": "^0.20.0"
@@ -430,9 +430,9 @@
 			"integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw=="
 		},
 		"node_modules/weas": {
-			"version": "0.1.36",
-			"resolved": "https://registry.npmjs.org/weas/-/weas-0.1.36.tgz",
-			"integrity": "sha512-hPLZfxJ5kVCCu1hF/J+uAQUo7fv/Ms1zI09QNgwwZ9Jacsm+67+YCYz4QT2x4e7eQFy4O0XK0eYzZ1vB5oBd3g==",
+			"version": "0.1.37",
+			"resolved": "https://registry.npmjs.org/weas/-/weas-0.1.37.tgz",
+			"integrity": "sha512-ES0FSPDfJ6lYUBnwgNn/8JklRxLtq/3pd0ys6f0TjZW1kjvVjy3vBpUBebx0nAJCz1hX8RfoZA1c7GbBOf+C8A==",
 			"dependencies": {
 				"dat.gui": "^0.7.9",
 				"three": "^0.169.0"
@@ -648,9 +648,9 @@
 			"integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw=="
 		},
 		"weas": {
-			"version": "0.1.36",
-			"resolved": "https://registry.npmjs.org/weas/-/weas-0.1.36.tgz",
-			"integrity": "sha512-hPLZfxJ5kVCCu1hF/J+uAQUo7fv/Ms1zI09QNgwwZ9Jacsm+67+YCYz4QT2x4e7eQFy4O0XK0eYzZ1vB5oBd3g==",
+			"version": "0.1.37",
+			"resolved": "https://registry.npmjs.org/weas/-/weas-0.1.37.tgz",
+			"integrity": "sha512-ES0FSPDfJ6lYUBnwgNn/8JklRxLtq/3pd0ys6f0TjZW1kjvVjy3vBpUBebx0nAJCz1hX8RfoZA1c7GbBOf+C8A==",
 			"requires": {
 				"dat.gui": "^0.7.9",
 				"three": "^0.169.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"dependencies": {
 		"dat.gui": "^0.7.9",
 		"three": "^0.161.0",
-		"weas": ">=0.1.36"
+		"weas": ">=0.1.37"
 	},
 	"devDependencies": {
 		"esbuild": "^0.20.0"

--- a/src/weas_widget/atoms_viewer.py
+++ b/src/weas_widget/atoms_viewer.py
@@ -24,6 +24,7 @@ class AtomsViewer(WidgetWrapper):
         "hide_long_bonds": "hideLongBonds",
         "show_atom_legend": "showAtomLegend",
         "show_hydrogen_bonds": "showHydrogenBonds",
+        "show_out_boundary_bonds": "showOutBoundaryBonds",
         "atom_label_type": "atomLabelType",
         "material_type": "materialType",
         "model_sticks": "modelSticks",

--- a/src/weas_widget/base_widget.py
+++ b/src/weas_widget/base_widget.py
@@ -33,6 +33,7 @@ class BaseWidget(anywidget.AnyWidget):
     showCell = tl.Bool(True).tag(sync=True)
     showBondedAtoms = tl.Bool(False).tag(sync=True)
     showHydrogenBonds = tl.Bool(False).tag(sync=True)
+    showOutBoundaryBonds = tl.Bool(False).tag(sync=True)
     hideLongBonds = tl.Bool(True).tag(sync=True)
     atomScales = tl.List().tag(sync=True)
     modelSticks = tl.List().tag(sync=True)


### PR DESCRIPTION

```python
from weas_widget import WeasWidget
from ase.io import read
atoms = read("datas/urea.cif")
viewer1 = WeasWidget()
viewer1.from_ase(atoms)
viewer1.avr.show_hydrogen_bonds = True
viewer1.avr.boundary = [[-0.1, 1.1], [-0.1, 1.1], [-0.1, 1.1]]
viewer1.avr.show_bonded_atoms = True
viewer1.avr.model_style = 2
viewer1.avr.show_out_boundary_bonds = True
viewer1
```

![image](https://github.com/user-attachments/assets/325c2000-21ec-4c20-ad83-6ac25cc9a262)
