### PR TITLE
Optimize frame update behavior

### DIFF
--- a/js/widget.js
+++ b/js/widget.js
@@ -91,6 +91,7 @@ function render({ model, el }) {
             },
             boundary: model.get("boundary"),
             currentFrame: model.get("currentFrame"),
+            continuousUpdate: model.get("continuousUpdate"),
         };
         editor = new weas.WEAS({ domElement, atoms, viewerConfig, guiConfig });
         window.editor = editor; // for debugging

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 			"dependencies": {
 				"dat.gui": "^0.7.9",
 				"three": "^0.161.0",
-				"weas": ">=0.1.41"
+				"weas": ">=0.1.42"
 			},
 			"devDependencies": {
 				"esbuild": "^0.20.0"
@@ -430,9 +430,9 @@
 			"integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw=="
 		},
 		"node_modules/weas": {
-			"version": "0.1.41",
-			"resolved": "https://registry.npmjs.org/weas/-/weas-0.1.41.tgz",
-			"integrity": "sha512-+KtI1fXHN3LBQpHVpVHW1YKztgf8zwf5xYJsnVwplef0SuuNgtT+l4v9JyZzhDA5oTYcLX10UeeAHuI+1CvagQ==",
+			"version": "0.1.42",
+			"resolved": "https://registry.npmjs.org/weas/-/weas-0.1.42.tgz",
+			"integrity": "sha512-95MTZ+raMiNoBGFYNFzB5+bN8g+/nlatpaEqEzDgoL0oqwU50KSoMiihl4T62ONFvDmxRcNBfWwGHQmLsM/LCQ==",
 			"dependencies": {
 				"dat.gui": "^0.7.9",
 				"three": "^0.169.0"
@@ -648,9 +648,9 @@
 			"integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw=="
 		},
 		"weas": {
-			"version": "0.1.41",
-			"resolved": "https://registry.npmjs.org/weas/-/weas-0.1.41.tgz",
-			"integrity": "sha512-+KtI1fXHN3LBQpHVpVHW1YKztgf8zwf5xYJsnVwplef0SuuNgtT+l4v9JyZzhDA5oTYcLX10UeeAHuI+1CvagQ==",
+			"version": "0.1.42",
+			"resolved": "https://registry.npmjs.org/weas/-/weas-0.1.42.tgz",
+			"integrity": "sha512-95MTZ+raMiNoBGFYNFzB5+bN8g+/nlatpaEqEzDgoL0oqwU50KSoMiihl4T62ONFvDmxRcNBfWwGHQmLsM/LCQ==",
 			"requires": {
 				"dat.gui": "^0.7.9",
 				"three": "^0.169.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"dependencies": {
 		"dat.gui": "^0.7.9",
 		"three": "^0.161.0",
-		"weas": ">=0.1.41"
+		"weas": ">=0.1.42"
 	},
 	"devDependencies": {
 		"esbuild": "^0.20.0"

--- a/src/weas_widget/atoms_viewer.py
+++ b/src/weas_widget/atoms_viewer.py
@@ -33,6 +33,7 @@ class AtomsViewer(WidgetWrapper):
         "model_polyhedras": "modelPolyhedras",
         "current_frame": "currentFrame",
         "phonon_setting": "phonon",
+        "continuous_update": "continuousUpdate",
     }
 
     _extra_allowed_attrs = [

--- a/src/weas_widget/base_widget.py
+++ b/src/weas_widget/base_widget.py
@@ -76,6 +76,7 @@ class BaseWidget(anywidget.AnyWidget):
     highlightSettings = tl.Dict().tag(sync=True)
     #
     showAtomLegend = tl.Bool(False).tag(sync=True)
+    continuousUpdate = tl.Bool(True).tag(sync=True)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Bump weas to `0.1.42`.

- In playing mode, only update the meshes (bonds, polyhedra) with new atom positions, not re-draw, e.g., the number of polyhedra will not change.
- In paused mode, behavior depends on the `continuous_update` setting
  - Default (continuous_update = true): full re-draw models continuously (updates bonds, image atoms, and polyhedra in real-time) when the user drags the timeline slider.
  - When disabled (continuous_update = false): full re-draw happens only when the user confirms the frame.



Here is an example:


https://github.com/user-attachments/assets/a510c015-6a10-4f89-944a-d35fd3165a6c


